### PR TITLE
Change inputs to textareas

### DIFF
--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react';
 import QRCode from 'qrcode.react';
+import { useEffect, useState } from 'react';
 import './style.css';
 
 export const Card = () => {
@@ -51,7 +51,7 @@ export const Card = () => {
 
           <div className="text">
             <label>Network name</label>
-            <input
+            <textarea
               id="ssid"
               type="text"
               maxLength="32"
@@ -60,7 +60,7 @@ export const Card = () => {
               onChange={(e) => setNetwork({ ...network, ssid: e.target.value })}
             />
             <label>Password</label>
-            <input
+            <textarea
               id="password"
               type="text"
               maxLength="63"

--- a/src/components/style.css
+++ b/src/components/style.css
@@ -14,13 +14,15 @@
 .details .text * {
   margin: 0 1em;
 }
-.details .text input {
+.details .text textarea {
   background-color: #fff;
   border: solid 1px #ddd;
   font-family: 'Source Code Pro', serif;
-  font-size: 1.4em;
+  font-size: 1.3em;
   font-weight: bold;
-  line-height: 2;
+  height: 3em;
+  overflow: hidden;
+  resize: none;
 }
 .print-btn {
   padding-top: 2em;

--- a/src/style.css
+++ b/src/style.css
@@ -1,5 +1,5 @@
 body {
-  max-width: 650px;
+  max-width: 680px;
 }
 .tag {
   line-height: 1.6;


### PR DESCRIPTION
Issue #28 discovered long ssid and password values would be visibly cropped.
This change replaces the input fields with 2-row textareas that properly
handle the maximum length of both ssids and passwords, 32 and 63 characters
respectively.

Fixes #28

<hr />

<img width="724" alt="image" src="https://user-images.githubusercontent.com/4248167/124627098-1eb86a00-de34-11eb-8f6f-036783a45688.png">

<hr />

<img width="949" alt="image" src="https://user-images.githubusercontent.com/4248167/124627056-152f0200-de34-11eb-92f3-9b6cb9690b40.png">
