### PR TITLE
[Feature Request #39] Added encryption options

### DIFF
--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -7,6 +7,7 @@ export const Card = () => {
   const [qrvalue, setQrvalue] = useState('');
   const [network, setNetwork] = useState({
     ssid: '',
+    encryptionMode: 'not-set',
     password: '',
     hidePassword: false,
   });
@@ -30,6 +31,8 @@ export const Card = () => {
   const onPrint = () => {
     if (network.password.length < 8) {
       alert('Password must be at least 8 characters');
+    } else if (network.encryptionMode === 'not-set') {
+      alert('Encryption mode not set')
     } else {
       window.print();
     }
@@ -43,7 +46,8 @@ export const Card = () => {
 
     const ssid = escape(network.ssid);
     const password = escape(network.password);
-    setQrvalue(`WIFI:T:WPA;S:${ssid};P:${password};;`);
+    const encryptionMode = escape(network.encryptionMode)
+    setQrvalue(`WIFI:T:${encryptionMode};S:${ssid};P:${password};;`);
   }, [network]);
 
   return (
@@ -113,6 +117,50 @@ export const Card = () => {
             <label for="hide-password-checkbox" className="hide-password">
               Hide password field before printing
             </label>
+
+            <br/><br/>
+
+            <label>Encryption</label>
+            <input
+              type="radio"
+              name="encrypt-select"
+              id="encrypt-none"
+              value=""
+              onChange={(e) =>
+                setNetwork({ ...network, encryptionMode: e.target.value })
+              }
+            />
+            <label
+              for="encrypt-none">
+                None
+            </label>
+            <input
+              type="radio"
+              name="encrypt-select"
+              id="encrypt-wpa-wpa2"
+              value="WPA"
+              onChange={(e) =>
+                setNetwork({ ...network, encryptionMode: e.target.value })
+              }
+            />
+            <label
+              for="encrypt-wpa-wpa2">
+                WPA/WPA2
+            </label>
+            <input
+              type="radio"
+              name="encrypt-select"
+              id="encrypt-wep"
+              value="WEP"
+              onChange={(e) =>
+                setNetwork({ ...network, encryptionMode: e.target.value })
+              }
+            />
+            <label
+              for="encrypt-wep">
+                WEP
+            </label>
+
           </div>
         </div>
 

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -6,9 +6,9 @@ export const Card = () => {
   const firstLoad = useRef(true);
   const [qrvalue, setQrvalue] = useState('');
   const [network, setNetwork] = useState({
-    ssid: '',
-    encryptionMode: 'not-set',
-    password: '',
+    ssid: "",
+    encryptionMode: "not-set",
+    password: "",
     hidePassword: false,
   });
   const [portrait, setPortrait] = useState(false);
@@ -29,10 +29,12 @@ export const Card = () => {
   };
 
   const onPrint = () => {
-    if (network.password.length < 8) {
+    if (network.password.length < 8 && network.encryptionMode === "WPA") {
       alert('Password must be at least 8 characters');
-    } else if (network.encryptionMode === 'not-set') {
-      alert('Encryption mode not set')
+    } else if (network.password.length < 5 && network.encryptionMode === "WEP") {
+      alert('Password must be at least 5 characters');
+    } else if (network.encryptionMode === "not-set") {
+      alert('Please set an encryption mode')
     } else {
       window.print();
     }
@@ -101,9 +103,9 @@ export const Card = () => {
               autoCapitalize="none"
               spellCheck="false"
               value={network.password}
-              onChange={(e) =>
+              onChange={(e) => {
                 setNetwork({ ...network, password: e.target.value })
-              }
+              }}
             />
 
             <input
@@ -120,7 +122,7 @@ export const Card = () => {
 
             <br/><br/>
 
-            <label>Encryption</label>
+            <label>Encryption: </label>
             <input
               type="radio"
               name="encrypt-select"

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -122,44 +122,53 @@ export const Card = () => {
 
             <br/><br/>
 
-            <label>Encryption: </label>
+            <label
+              className="hide-encrypt">
+              Encryption:
+            </label>
             <input
               type="radio"
               name="encrypt-select"
               id="encrypt-none"
+              className="hide-encrypt"
               value=""
               onChange={(e) =>
                 setNetwork({ ...network, encryptionMode: e.target.value })
               }
             />
             <label
-              for="encrypt-none">
+              for="encrypt-none"
+              className="hide-encrypt">
                 None
             </label>
             <input
               type="radio"
               name="encrypt-select"
               id="encrypt-wpa-wpa2"
+              className="hide-encrypt"
               value="WPA"
               onChange={(e) =>
                 setNetwork({ ...network, encryptionMode: e.target.value })
               }
             />
             <label
-              for="encrypt-wpa-wpa2">
+              for="encrypt-wpa-wpa2"
+              className="hide-encrypt">
                 WPA/WPA2
             </label>
             <input
               type="radio"
               name="encrypt-select"
               id="encrypt-wep"
+              className="hide-encrypt"
               value="WEP"
               onChange={(e) =>
                 setNetwork({ ...network, encryptionMode: e.target.value })
               }
             />
             <label
-              for="encrypt-wep">
+              for="encrypt-wep"
+              className="hide-encrypt">
                 WEP
             </label>
 

--- a/src/components/style.css
+++ b/src/components/style.css
@@ -59,6 +59,9 @@ button#rotate {
   .hide-password {
     display: none;
   }
+  .hide-encrypt {
+    display: none;
+  }
   #print-area {
     position: absolute;
     left: 0;


### PR DESCRIPTION
Feature request #39 asked for encryption options. This change adds support for choosing WPA/WPA2 encryption, WEP, and none (for public networks).

**For "None" encryption option**: No minimum password length is enforced. Per #39, encryption mode is set to an empty string.

**For "WPA/WPA2" option**: A minimum password length of 8 is enforced. Encryption mode is set to "WPA".

**For "WEP" option**: Per issue #29, a minimum password length of 5 is enforced. Encryption mode is set to "WEP". Alert message has been added if this condition is not met.

Encryption setting must be chosen to print the page. Appropriate alert has been added to enforce this.