### PR TITLE
generated PDF has name WiFi Card with your network name

### DIFF
--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -39,6 +39,7 @@ export const Card = () => {
       ) {
         alert(t('wifi.alert.password.length.5'));
       } else {
+        document.title = 'WiFi Card - ' + network.ssid;
         window.print();
       }
     } else {


### PR DESCRIPTION
When you save a file as PDF on your disk, the WiFi network name is added to the file name to avoid overwriting the previous file for another network. For example:
`WiFi Card - MyNetworkName.pdf`

It can also be useful for quickly locating a file for a specific network - without opening the PDF, just look at the file name.
The filename can also be useful when printing to see which document is printing or on which document the printer has stopped printing.