### PR TITLE
hide password option is possible when password has correct length for…

### DIFF
--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -46,13 +46,13 @@ export const Card = () => {
     }
   };
 
-  const isWEPWithPasswordLengthShorterThat5Characters = () => {
-    return network.encryptionMode === 'WEP' && network.password.length < 5
-      ? true
-      : false;
-  };
-
   const disableHidePassword = () => {
+    const isWEPWithPasswordLengthShorterThat5Characters = () => {
+      return network.encryptionMode === 'WEP' && network.password.length < 5
+        ? true
+        : false;
+    };
+
     return network.encryptionMode === 'WPA' && network.password.length < 8
       ? true
       : isWEPWithPasswordLengthShorterThat5Characters();

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -46,12 +46,16 @@ export const Card = () => {
     }
   };
 
+  const isWEPWithPasswordLengthShorterThat5Characters = () => {
+    return network.encryptionMode === 'WEP' && network.password.length < 5
+      ? true
+      : false;
+  };
+
   const disableHidePassword = () => {
     return network.encryptionMode === 'WPA' && network.password.length < 8
       ? true
-      : network.encryptionMode === 'WEP' && network.password.length < 5
-      ? true
-      : false;
+      : isWEPWithPasswordLengthShorterThat5Characters();
   };
 
   useEffect(() => {

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -127,6 +127,15 @@ export const Card = () => {
               <input
                 type="checkbox"
                 id="hide-password-checkbox"
+                disabled={
+                  network.encryptionMode === 'WPA' &&
+                  network.password.length < 8
+                    ? true
+                    : network.encryptionMode === 'WEP' &&
+                      network.password.length < 5
+                    ? true
+                    : false
+                }
                 className={network.encryptionMode === 'nopass' ? 'hidden' : ''}
                 onChange={() =>
                   setNetwork({

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -46,6 +46,14 @@ export const Card = () => {
     }
   };
 
+  const disableHidePassword = () => {
+    return network.encryptionMode === 'WPA' && network.password.length < 8
+      ? true
+      : network.encryptionMode === 'WEP' && network.password.length < 5
+      ? true
+      : false;
+  };
+
   useEffect(() => {
     if (firstLoad.current && window.innerWidth < 500) {
       firstLoad.current = false;
@@ -127,15 +135,7 @@ export const Card = () => {
               <input
                 type="checkbox"
                 id="hide-password-checkbox"
-                disabled={
-                  network.encryptionMode === 'WPA' &&
-                  network.password.length < 8
-                    ? true
-                    : network.encryptionMode === 'WEP' &&
-                      network.password.length < 5
-                    ? true
-                    : false
-                }
+                disabled={disableHidePassword()}
                 className={network.encryptionMode === 'nopass' ? 'hidden' : ''}
                 onChange={() =>
                   setNetwork({


### PR DESCRIPTION
… WEP and WPA

At the moment you can check the box to hide the password on the printout even though the password is empty or has fewer than 5 characters for WEP and less than 8 characters for WPA / WPA2.
This PR allows you to enable password hiding only if a password is already provided. 
Until now, we were able to hide the password and get a message that the correct password should be entered even though the password field was not visible.

It works in such a way that the checkbox `Hide password field before printing` is not clickable until the correct value in the password field.