### PR TITLE
add message that Internet Explorer is not supported

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -48,7 +48,7 @@
   const isIE = /*@cc_on!@*/false || !!document.documentMode;
 
   if (isIE) {
-    document.getElementById("root").innerHTML = "Internet Explorer is not supported. Download Chrome/Opera/Firefox.";
+    document.getElementById("root").innerHTML = "Internet Explorer is not supported. Download Firefox/Chrome/Opera.";
   }
 </script>
 

--- a/public/index.html
+++ b/public/index.html
@@ -1,18 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta name="description" content="Print a card for your WiFi login" />
-    <link rel="icon" href="./images/wifi.ico" />
-    <link rel="stylesheet" href="/light.min.css" />
-    <!--
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="description" content="Print a card for your WiFi login" />
+  <link rel="icon" href="./images/wifi.ico" />
+  <link rel="stylesheet" href="/light.min.css" />
+  <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
+  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -21,15 +22,16 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>WiFi Card</title>
-  </head>
-  <body>
-    <noscript
-      >You need to enable JavaScript to run this app. Feel free to view the
-      <a href="https://github.com/bndw/wifi-card">source code</a>.</noscript
-    >
-    <div id="root"></div>
-    <!--
+  <title>WiFi Card</title>
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app. Feel free to view the
+    <a href="https://github.com/bndw/wifi-card">source code</a>.</noscript>
+
+  <div id="root">
+  </div>
+  <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.
 
@@ -39,5 +41,15 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-  </body>
+</body>
+
+<script>
+  // Internet Explorer 6-11
+  const isIE = /*@cc_on!@*/false || !!document.documentMode;
+
+  if (isIE) {
+    document.getElementById("root").innerHTML = "Internet Explorer is not supported. Download Chrome/Opera/Firefox.";
+  }
+</script>
+
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -49,6 +49,7 @@
 
   if (isIE) {
     document.getElementById("root").innerHTML = "Internet Explorer is not supported. Download Firefox/Chrome/Opera.";
+    document.body.style.fontSize="50px";
   }
 </script>
 


### PR DESCRIPTION
Related to: https://github.com/bndw/wifi-card/issues/92

Another idea is using [react-device-detect](https://bundlephobia.com/package/react-device-detect@1.17.0).
Example:

```
import {isIE} from 'react-device-detect';

render() {
    if (isIE) return <div> IE is not supported. Download Chrome/Opera/Firefox </div>
    return (
        <div>...content</div>
    )
}
```

I was trying by this way but in IE but in IE, the error is thrown earlier - before it gets to the point where the browser is checked. Because if I did a test that I simulated that Chrome is Internet Explorer (by inverting the if condition) then I got the message correctly.

So I did it via JavaScript. This is just a suggestion