### PR TITLE
remember the password even if it is cleared by the None option

### DIFF
--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -10,6 +10,7 @@ export const Card = ({ direction = 'ltr' }) => {
     ssid: '',
     encryptionMode: 'WPA',
     password: '',
+    tmpPassword: '',
     hidePassword: false,
   });
   const [portrait, setPortrait] = useState(false);
@@ -173,6 +174,7 @@ export const Card = ({ direction = 'ltr' }) => {
                   setNetwork({
                     ...network,
                     encryptionMode: e.target.value,
+                    tmpPassword: network.password,
                     password: '',
                   });
                 }}
@@ -184,7 +186,11 @@ export const Card = ({ direction = 'ltr' }) => {
                 id="encrypt-wpa-wpa2-wpa3"
                 value="WPA"
                 onChange={(e) =>
-                  setNetwork({ ...network, encryptionMode: e.target.value })
+                  setNetwork({
+                    ...network,
+                    encryptionMode: e.target.value,
+                    password: network.tmpPassword,
+                  })
                 }
                 defaultChecked
               />
@@ -195,7 +201,11 @@ export const Card = ({ direction = 'ltr' }) => {
                 id="encrypt-wep"
                 value="WEP"
                 onChange={(e) =>
-                  setNetwork({ ...network, encryptionMode: e.target.value })
+                  setNetwork({
+                    ...network,
+                    encryptionMode: e.target.value,
+                    password: network.tmpPassword,
+                  })
                 }
               />
               <label htmlFor="encrypt-wep">WEP</label>

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -10,7 +10,6 @@ export const Card = ({ direction = 'ltr' }) => {
     ssid: '',
     encryptionMode: 'WPA',
     password: '',
-    tmpPassword: '',
     hidePassword: false,
   });
   const [portrait, setPortrait] = useState(false);
@@ -66,7 +65,8 @@ export const Card = ({ direction = 'ltr' }) => {
     }
 
     const ssid = escape(network.ssid);
-    const password = escape(network.password);
+    const password =
+      network.encryptionMode === 'None' ? '' : escape(network.password);
     setQrvalue(`WIFI:T:${network.encryptionMode};S:${ssid};P:${password};;`);
   }, [network]);
 
@@ -171,50 +171,46 @@ export const Card = ({ direction = 'ltr' }) => {
                 {t('wifi.password.encryption')}:{direction === 'rtl' ? ' ' : ''}
               </label>
               <span dir="ltr">
-<input
-                type="radio"
-                name="encrypt-select"
-                id="encrypt-none"
-                value="nopass"
-                onChange={(e) => {
-                  setNetwork({
-                    ...network,
-                    encryptionMode: e.target.value,
-                    tmpPassword: network.password,
-                    password: '',
-                  });
-                }}
-              />
-              <label htmlFor="encrypt-none">None</label>
-              <input
-                type="radio"
-                name="encrypt-select"
-                id="encrypt-wpa-wpa2-wpa3"
-                value="WPA"
-                onChange={(e) =>
-                  setNetwork({
-                    ...network,
-                    encryptionMode: e.target.value,
-                    password: network.tmpPassword,
-                  })
-                }
-                defaultChecked
-              />
-              <label htmlFor="encrypt-wpa-wpa2-wpa3">WPA/WPA2/WPA3</label>
-              <input
-                type="radio"
-                name="encrypt-select"
-                id="encrypt-wep"
-                value="WEP"
-                onChange={(e) =>
-                  setNetwork({
-                    ...network,
-                    encryptionMode: e.target.value,
-                    password: network.tmpPassword,
-                  })
-                }
-              />
-              <label htmlFor="encrypt-wep">WEP</label>
+                <input
+                  type="radio"
+                  name="encrypt-select"
+                  id="encrypt-none"
+                  value="nopass"
+                  onChange={(e) => {
+                    setNetwork({
+                      ...network,
+                      encryptionMode: e.target.value,
+                    });
+                  }}
+                />
+                <label htmlFor="encrypt-none">None</label>
+                <input
+                  type="radio"
+                  name="encrypt-select"
+                  id="encrypt-wpa-wpa2-wpa3"
+                  value="WPA"
+                  onChange={(e) =>
+                    setNetwork({
+                      ...network,
+                      encryptionMode: e.target.value,
+                    })
+                  }
+                  defaultChecked
+                />
+                <label htmlFor="encrypt-wpa-wpa2-wpa3">WPA/WPA2/WPA3</label>
+                <input
+                  type="radio"
+                  name="encrypt-select"
+                  id="encrypt-wep"
+                  value="WEP"
+                  onChange={(e) =>
+                    setNetwork({
+                      ...network,
+                      encryptionMode: e.target.value,
+                    })
+                  }
+                />
+                <label htmlFor="encrypt-wep">WEP</label>
               </span>
             </div>
           </div>

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -66,7 +66,7 @@ export const Card = ({ direction = 'ltr' }) => {
 
     const ssid = escape(network.ssid);
     const password =
-      network.encryptionMode === 'None' ? '' : escape(network.password);
+      network.encryptionMode === 'nopass' ? '' : escape(network.password);
     setQrvalue(`WIFI:T:${network.encryptionMode};S:${ssid};P:${password};;`);
   }, [network]);
 
@@ -165,8 +165,6 @@ export const Card = ({ direction = 'ltr' }) => {
             </div>
 
             <div className="no-print">
-              <label>{t('wifi.password.encryption')}:</label>
-
               <label>
                 {t('wifi.password.encryption')}:{direction === 'rtl' ? ' ' : ''}
               </label>


### PR DESCRIPTION
This improvement of this PR https://github.com/bndw/wifi-card/issues/46. It ensures that the user does not lose the value entered in the password. Currently, if he enters a password and accidentally or out of curiosity clicks `None` and then selects WPA/WEP again, his password will be empty - without a value, he has to re-enter it.
This PR causes the user's password to never be cleared.
Of course, even if this password is remembered, with the `None` option it will not be taken into account when generating the QR Code for the network.