### PR TITLE
Add checkbox state to fix issue

### DIFF
--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -13,7 +13,6 @@ export const Card = ({ direction = 'ltr' }) => {
     hidePassword: false,
   });
   const [portrait, setPortrait] = useState(false);
-  const [checkbox, setCheckbox] = useState(false);
   const { t } = useTranslation();
   const escape = (v) => {
     const needsEscape = ['"', ';', ',', ':', '\\'];
@@ -147,16 +146,15 @@ export const Card = ({ direction = 'ltr' }) => {
               <input
                 type="checkbox"
                 id="hide-password-checkbox"
-                checked={checkbox}
+                checked={network.hidePassword}
                 disabled={disableHidePassword()}
                 className={network.encryptionMode === 'nopass' ? 'hidden' : ''}
-                onChange={() => {
-                  setCheckbox(!checkbox);
+                onChange={() =>
                   setNetwork({
                     ...network,
                     hidePassword: !network.hidePassword,
-                  });
-                }}
+                  })
+                }
               />
               <label
                 htmlFor="hide-password-checkbox"
@@ -181,6 +179,7 @@ export const Card = ({ direction = 'ltr' }) => {
                       ...network,
                       encryptionMode: e.target.value,
                       password: '',
+                      hidePassword: false,
                     });
                   }}
                 />
@@ -191,7 +190,12 @@ export const Card = ({ direction = 'ltr' }) => {
                   id="encrypt-wpa-wpa2-wpa3"
                   value="WPA"
                   onChange={(e) =>
-                    setNetwork({ ...network, encryptionMode: e.target.value })
+                    setNetwork({
+                      ...network,
+                      encryptionMode: e.target.value,
+                      hidePassword:
+                        network.password.length !== 0 && network.hidePassword,
+                    })
                   }
                   defaultChecked
                 />
@@ -202,7 +206,12 @@ export const Card = ({ direction = 'ltr' }) => {
                   id="encrypt-wep"
                   value="WEP"
                   onChange={(e) =>
-                    setNetwork({ ...network, encryptionMode: e.target.value })
+                    setNetwork({
+                      ...network,
+                      encryptionMode: e.target.value,
+                      hidePassword:
+                        network.password.length !== 0 && network.hidePassword,
+                    })
                   }
                 />
                 <label htmlFor="encrypt-wep">WEP</label>

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -13,6 +13,7 @@ export const Card = ({ direction = 'ltr' }) => {
     hidePassword: false,
   });
   const [portrait, setPortrait] = useState(false);
+  const [checkbox, setCheckbox] = useState(false);
   const { t } = useTranslation();
   const escape = (v) => {
     const needsEscape = ['"', ';', ',', ':', '\\'];
@@ -146,14 +147,16 @@ export const Card = ({ direction = 'ltr' }) => {
               <input
                 type="checkbox"
                 id="hide-password-checkbox"
+                checked={checkbox}
                 disabled={disableHidePassword()}
                 className={network.encryptionMode === 'nopass' ? 'hidden' : ''}
-                onChange={() =>
+                onChange={() => {
+                  setCheckbox(!checkbox);
                   setNetwork({
                     ...network,
                     hidePassword: !network.hidePassword,
-                  })
-                }
+                  });
+                }}
               />
               <label
                 htmlFor="hide-password-checkbox"

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -193,8 +193,6 @@ export const Card = ({ direction = 'ltr' }) => {
                     setNetwork({
                       ...network,
                       encryptionMode: e.target.value,
-                      hidePassword:
-                        network.password.length !== 0 && network.hidePassword,
                     })
                   }
                   defaultChecked
@@ -209,8 +207,6 @@ export const Card = ({ direction = 'ltr' }) => {
                     setNetwork({
                       ...network,
                       encryptionMode: e.target.value,
-                      hidePassword:
-                        network.password.length !== 0 && network.hidePassword,
                     })
                   }
                 />


### PR DESCRIPTION
Fixes #132 
I add a checkbox state.
```diff
+ hidePassword: network.password.length !== 0 && checkbox
```
this is the main logic used to fix the bug !
### How it works
we want to set `hidePassword` to `false` when we set encryption from `none` --> `WEP/WPA`
for this i check the password length , if it's zero it will suggest we moved from `none` --> `WEP/WPA`

but this logic will set `hidePassword` to `true` when length is not 0 and we move from `WPA` --> `WEP` or other way
hence we also need to add a check if the checkbox is selected or not !

## Preview

![demo](https://user-images.githubusercontent.com/54404738/127421848-9f74b2d0-6e34-4a01-8bd3-c5e42b8eb67c.gif)


