### PR TITLE
Language dropdown formatting

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -34,27 +34,27 @@ function App() {
           value={i18n.language}
           onChange={(e) => changeLanguage(e.target.value)}
         >
-          <option value="en-US">English - US (English)</option>
-          <option value="zh-HK">Chinese - Hong Kong (简体中文)</option>
-          <option value="zh-CN">Chinese - Simplified (简体中文)</option>
-          <option value="es">Spanish (Español)</option>
-          <option value="pt">Portuguese (Português)</option>
-          <option value="pt-BR">Portuguese (Brazil)</option>
-          <option value="ja">Japanese (日本語)</option>
-          <option value="fa-IR">Persian - Iran (فارسی)</option>
-          <option value="ru-RU">Russian - Russia (Русский)</option>
-          <option value="uk-UA">Ukrainian - Ukraine (Українська)</option>
-          <option value="nl-NL">Dutch - Netherlands (Nederlands)</option>
-          <option value="fr-FR">French - FR (Français)</option>
-          <option value="tr-TR">Turkish - Turkey (Türkçe)</option>
-          <option value="hi-IN">Hindi - India (हिन्दी)</option>
-          <option value="ca">Catalan (català)</option>
-          <option value="de-DE">German (Germany)</option>
-          <option value="id-ID">Indonesian (Indonesia)</option>
-          <option value="pl-PL">Polish - PL (Polski)</option>
           <option value="ar">Arabic - العربية</option>
-          <option value="oc">Occitan</option>
+          <option value="ca">Catalan - Català</option>
+          <option value="zh-HK">Chinese Hong Kong - 简体中文</option>
+          <option value="zh-CN">Chinese Simplified - 简体中文</option>
+          <option value="nl-NL">Dutch - Nederlands</option>
+          <option value="en-US">English</option>
+          <option value="fr-FR">French - Français</option>
+          <option value="de-DE">German - Germany</option>
+          <option value="hi-IN">Hindi - हिन्दी</option>
+          <option value="id-ID">Indonesian</option>
           <option value="it-IT">Italian</option>
+          <option value="ja">Japanese - 日本語</option>
+          <option value="oc">Occitan</option>
+          <option value="fa-IR">Persian Iran - فارسی</option>
+          <option value="pl-PL">Polish - Polski</option>
+          <option value="pt">Portuguese - Português</option>
+          <option value="pt-BR">Portuguese - Brazil</option>
+          <option value="ru-RU">Russian - Русский</option>
+          <option value="es">Spanish - Español</option>
+          <option value="tr-TR">Turkish - Türkçe</option>
+          <option value="uk-UA">Ukrainian - Українська</option>
         </select>
       </div>
 

--- a/src/App.js
+++ b/src/App.js
@@ -50,7 +50,7 @@ function App() {
           <option value="fa-IR">Persian Iran - فارسی</option>
           <option value="pl-PL">Polish - Polski</option>
           <option value="pt">Portuguese - Português</option>
-          <option value="pt-BR">Portuguese - Brazil</option>
+          <option value="pt-BR">Portuguese - Português brasileiro</option>
           <option value="ru-RU">Russian - Русский</option>
           <option value="es">Spanish - Español</option>
           <option value="tr-TR">Turkish - Türkçe</option>

--- a/src/App.js
+++ b/src/App.js
@@ -39,7 +39,7 @@ function App() {
           <option value="zh-HK">Chinese Hong Kong - 简体中文</option>
           <option value="zh-CN">Chinese Simplified - 简体中文</option>
           <option value="nl-NL">Dutch - Nederlands</option>
-          <option value="en-US">English</option>
+          <option value="en">English</option>
           <option value="fr-FR">French - Français</option>
           <option value="de-DE">German - Germany</option>
           <option value="hi-IN">Hindi - हिन्दी</option>

--- a/src/App.js
+++ b/src/App.js
@@ -41,7 +41,7 @@ function App() {
           <option value="nl-NL">Dutch - Nederlands</option>
           <option value="en">English</option>
           <option value="fr-FR">French - Français</option>
-          <option value="de-DE">German - Germany</option>
+          <option value="de-DE">German - Deutsch</option>
           <option value="hi-IN">Hindi - हिन्दी</option>
           <option value="id-ID">Indonesian</option>
           <option value="it-IT">Italian</option>

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -3,7 +3,7 @@ import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
 
 const resources = {
-  'en-US': {
+  en: {
     translation: {
       title: 'WiFi Card',
       'desc.use':
@@ -560,7 +560,7 @@ i18n
   .use(initReactI18next)
   .use(LanguageDetector)
   .init({
-    fallbackLng: 'en-US',
+    fallbackLng: 'en',
     resources,
     interpolation: {
       escapeValue: false,


### PR DESCRIPTION
- Clean up formatting and sort order of language dropdown (https://github.com/bndw/wifi-card/issues/80)
  - `latinName - nativeName` format to account for `RTL` languages
  - Sort by latin name
- Use a generic English translation (related to https://github.com/bndw/wifi-card/pull/125)

cc: @Teraskull , @A-Tokyo 