### PR TITLE
Update language detection order

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -560,6 +560,10 @@ i18n
   .use(initReactI18next)
   .use(LanguageDetector)
   .init({
+    detection: {
+      order: ['localStorage'],
+      lookupLocalStorage: 'i18nextLng',
+    },
     fallbackLng: 'en',
     resources,
     interpolation: {


### PR DESCRIPTION
Fixes #152 
This is a temporary fix, i have added an option that will force the `i18next-browser-languagedetector` to only look at local storage and if language is not found go back to the fallback.

i tried it with navigator (browser-set-language) but produces the same problem ! 
unable to find anything on this bug !

# Preview
![out](https://user-images.githubusercontent.com/54404738/127692064-6354f1b9-53e8-4dab-8a04-0d1680a2efce.gif)


