### PR TITLE
Removes direction prop from wificard

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -114,7 +114,6 @@ function App() {
       </Pane>
 
       <WifiCard
-        direction={htmlDirection()}
         settings={settings}
         ssidError={errors.ssidError}
         passwordError={errors.passwordError}

--- a/src/components/WifiCard.js
+++ b/src/components/WifiCard.js
@@ -77,13 +77,7 @@ export const WifiCard = (props) => {
         >
           <QRCode
             className="qrcode"
-            style={
-              !props.settings.portrait
-                ? props.direction === 'ltr'
-                  ? { paddingRight: '1em' }
-                  : { paddingLeft: '1em' }
-                : {}
-            }
+            style={{ padding: '1em' }}
             value={qrvalue}
             size={150}
           />


### PR DESCRIPTION
This was causing a runtime error and isn't necessary.
Fixes #172