### PR TITLE
move js script to body - resolve Error: Stray start tag script.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,20 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Print a simple card with your WiFi login details. Tape it to the fridge, keep it in your wallet, etc."
-    />
-    <link rel="icon" href="./images/wifi.ico" />
-    <!--
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="description"
+    content="Print a simple card with your WiFi login details. Tape it to the fridge, keep it in your wallet, etc." />
+  <link rel="icon" href="./images/wifi.ico" />
+  <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
+  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -23,17 +22,15 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>WiFi Card</title>
-  </head>
+  <title>WiFi Card</title>
+</head>
 
-  <body>
-    <noscript
-      >You need to enable JavaScript to run this app. Feel free to view the
-      <a href="https://github.com/bndw/wifi-card">source code</a>.</noscript
-    >
+<body>
+  <noscript>You need to enable JavaScript to run this app. Feel free to view the
+    <a href="https://github.com/bndw/wifi-card">source code</a>.</noscript>
 
-    <div id="root"></div>
-    <!--
+  <div id="root"></div>
+  <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.
 
@@ -43,15 +40,16 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-    <script>
-      // Internet Explorer 6-11
-      const isIE = /*@cc_on!@*/ false || !!document.documentMode;
-  
-      if (isIE) {
-        document.getElementById('root').innerHTML =
-          'Internet Explorer is not supported. Download Firefox/Chrome/Opera.';
-        document.body.style.fontSize = '50px';
-      }
-    </script>
-  </body>
+  <script>
+    // Internet Explorer 6-11
+    const isIE = /*@cc_on!@*/ false || !!document.documentMode;
+
+    if (isIE) {
+      document.getElementById('root').innerHTML =
+        'Internet Explorer is not supported. Download Firefox/Chrome/Opera.';
+      document.body.style.fontSize = '50px';
+    }
+  </script>
+</body>
+
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -43,16 +43,15 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
+    <script>
+      // Internet Explorer 6-11
+      const isIE = /*@cc_on!@*/ false || !!document.documentMode;
+  
+      if (isIE) {
+        document.getElementById('root').innerHTML =
+          'Internet Explorer is not supported. Download Firefox/Chrome/Opera.';
+        document.body.style.fontSize = '50px';
+      }
+    </script>
   </body>
-
-  <script>
-    // Internet Explorer 6-11
-    const isIE = /*@cc_on!@*/ false || !!document.documentMode;
-
-    if (isIE) {
-      document.getElementById('root').innerHTML =
-        'Internet Explorer is not supported. Download Firefox/Chrome/Opera.';
-      document.body.style.fontSize = '50px';
-    }
-  </script>
 </html>


### PR DESCRIPTION
Thanks to this, page in the html validator passes the test.

It resolves:

> Error: Stray start tag script.
> From line 1, column 2312; to line 1, column 2326
> ></script></body><script>const 

[in html validator](https://validator.w3.org/nu/?showsource=yes&doc=https%3A%2F%2Fwificard.io%2F).

btw, [CSS passed validation](https://validator.w3.org/unicorn/check?warning=1&ucn_task=full-css&usermedium=all&ucn_uri=https%3A%2F%2Fwificard.io%2F&ucn_lang=en).

> This document has passed the test: W3C CSS Validator (Level 3)

<p>
    <a href="https://jigsaw.w3.org/css-validator/check/referer">
        <img style="border:0;width:88px;height:31px"
            src="https://jigsaw.w3.org/css-validator/images/vcss"
            alt="Valid CSS!" />
    </a>
</p>
<p>
    <a href="https://jigsaw.w3.org/css-validator/check/referer">
        <img style="border:0;width:88px;height:31px"
            src="https://jigsaw.w3.org/css-validator/images/vcss-blue"
            alt="Poprawny CSS!" />
    </a>
</p>