### PR TITLE
:bug: hotfix logo + icons padding for rtl languages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -101,7 +101,12 @@ function App() {
     <Pane>
       <Pane display="flex">
         <img alt="icon" src={logo} width="32" height="32" />
-        <Heading size={900} {...html.style.direction === 'rtl' ? { paddingRight: 16 } : { paddingLeft: 16 }}>
+        <Heading
+          size={900}
+          {...(html.style.direction === 'rtl'
+            ? { paddingRight: 16 }
+            : { paddingLeft: 16 })}
+        >
           {t('title')}
         </Heading>
       </Pane>

--- a/src/App.js
+++ b/src/App.js
@@ -101,7 +101,7 @@ function App() {
     <Pane>
       <Pane display="flex">
         <img alt="icon" src={logo} width="32" height="32" />
-        <Heading size={900} paddingLeft={16}>
+        <Heading size={900} {...html.style.direction === 'rtl' ? { paddingRight: 16 } : { paddingLeft: 16 }}>
           {t('title')}
         </Heading>
       </Pane>

--- a/src/components/WifiCard.js
+++ b/src/components/WifiCard.js
@@ -17,6 +17,7 @@ import './style.css';
 export const WifiCard = (props) => {
   const { t } = useTranslation();
   const [qrvalue, setQrvalue] = useState('');
+  const html = document.querySelector('html');
 
   const escape = (v) => {
     const needsEscape = ['"', ';', ',', ':', '\\'];
@@ -132,7 +133,12 @@ export const WifiCard = (props) => {
         <Paragraph>
           <CameraIcon />
           <MobilePhoneIcon />
-          <Text size={300} paddingLeft={8}>
+          <Text
+            size={300}
+            {...(html.style.direction === 'rtl'
+              ? { paddingRight: 8 }
+              : { paddingLeft: 8 })}
+          >
             {t('wifi.tip')}
           </Text>
         </Paragraph>

--- a/src/components/WifiCard.js
+++ b/src/components/WifiCard.js
@@ -64,7 +64,9 @@ export const WifiCard = (props) => {
         <Pane display="flex" paddingBottom={12}>
           <img alt="icon" src={logo} width="24" height="24" />
           <Heading
-            paddingLeft={10}
+            {...(html.style.direction === 'rtl'
+              ? { paddingRight: 10 }
+              : { paddingLeft: 10 })}
             size={700}
             textAlign={props.settings.portrait ? 'center' : 'unset'}
           >


### PR DESCRIPTION
- 🐛 fix logo padding for rtl languages by setting paddingRight instead of paddingLeft if html.style.direction is rtl

closes https://github.com/bndw/wifi-card/issues/203