### PR TITLE
Update build image to use lts tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine as builder
+FROM node:lts-alpine as builder
 
 WORKDIR /tmp
 COPY . .


### PR DESCRIPTION
Node 18 is end of life in a few month: https://endoflife.date/nodejs switch to use lts tag for build image