### PR TITLE
Fix: building warnings on useEffect and husky pre-commit updates

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
 # Format using prettier
-make fmt.write
+make fmt

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,2 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 # Format using prettier
 make fmt.write

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import { Button, Heading, Link, Pane, Paragraph } from 'evergreen-ui';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import logo from '../src/images/wifi.png';
 import { Settings } from './components/Settings';
@@ -32,11 +32,11 @@ function App() {
     eapIdentityError: '',
   });
 
-  const htmlDirection = (languageID) => {
+  const htmlDirection = useCallback((languageID) => {
     languageID = languageID || i18n.language;
     const rtl = Translations.filter((t) => t.id === languageID)[0]?.rtl;
     return rtl ? 'rtl' : 'ltr';
-  };
+  }, [i18n.language]);
 
   const onChangeLanguage = (language) => {
     html.style.direction = htmlDirection(language);
@@ -136,7 +136,7 @@ function App() {
     if (htmlDirection() === 'rtl') {
       html.style.direction = 'rtl';
     }
-  }, []);
+  }, [html.style, htmlDirection]);
 
   return (
     <Pane>

--- a/src/App.js
+++ b/src/App.js
@@ -32,11 +32,14 @@ function App() {
     eapIdentityError: '',
   });
 
-  const htmlDirection = useCallback((languageID) => {
-    languageID = languageID || i18n.language;
-    const rtl = Translations.filter((t) => t.id === languageID)[0]?.rtl;
-    return rtl ? 'rtl' : 'ltr';
-  }, [i18n.language]);
+  const htmlDirection = useCallback(
+    (languageID) => {
+      languageID = languageID || i18n.language;
+      const rtl = Translations.filter((t) => t.id === languageID)[0]?.rtl;
+      return rtl ? 'rtl' : 'ltr';
+    },
+    [i18n.language]
+  );
 
   const onChangeLanguage = (language) => {
     html.style.direction = htmlDirection(language);


### PR DESCRIPTION

Fixing the following errors for passing building checks.
```shell
[eslint] 
src/App.js
  Line 139:6:  React Hook useEffect has missing dependencies: 'html.style' and 'htmlDirection'. Either include them or remove the dependency array  react-hooks/exhaustive-deps
[eslint] 
src/App.js
  Line 35:9:  The 'htmlDirection' function makes the dependencies of useEffect Hook (at line 139) change on every render. To fix this, wrap the definition of 'htmlDirection' in its own useCallback() Hook  react-hooks/exhaustive-deps
 ```
 
 I also noted that husky's command is deprecated, and the fmt.write does not prevent me from committing unlinted codes.
 
 ```shell
 pnpm prepare

> wifi-card@0.1.0 prepare ./wifi-card
> husky install

husky - install command is DEPRECATED
```